### PR TITLE
Replace deprecated facebook/webdriver with php-webdriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
     "phpunit/phpunit-selenium": "*",
-    "facebook/webdriver": "dev-master"
-  }  
+    "php-webdriver/webdriver": "^1.9.0"
+  }
 }


### PR DESCRIPTION
```
$ composer install

> Package facebook/webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```

