### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,212 +1,112 @@
-# Run Selenium Tests With PHP — TestMu AI (Formerly LambdaTest)
+# Run Selenium Tests with PHP on TestMu AI (Formerly LambdaTest)
 
-![image](https://user-images.githubusercontent.com/70570645/171994020-d3c81aca-bd93-4467-a372-ff0283fef8df.png)
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.php.net/"><img src="https://img.shields.io/badge/PHP-8.x-777BB4.svg?style=for-the-badge&labelColor=000000" alt="PHP version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to run your PHP automation testing scripts on the TestMu AI platform*
+## Getting Started
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
+With TestMu AI (Formerly LambdaTest), you can run Selenium tests in PHP across real browsers and operating systems. This sample shows how to configure PHP Selenium tests to run on the TestMu AI cloud.
 
-## Table Of Contents
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-* [Pre-requisites](#pre-requisites)
-* [Run Your First Test](#run-your-first-test)
-* [Local Testing With PHP](#testing-locally-hosted-or-privately-hosted-projects)
+### Prerequisites
 
-## Prerequisites
+- PHP 8.x
+- Composer
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-Before you begin automation testing with Selenium, you would need to:
+### Setup
 
-* Make sure that you have the latest **PHP** installed on your system. You can download and install **PHP** using following commands in the terminal:
-
-  * **MacOS:** Previous versions of **MacOS** have **PHP** installed by default. But for the latest **MacOS** versions starting with **Monterey**, **PHP** has to be downloaded and installed manually by using below commands: 
-  ```bash
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  brew install php
-  ```
-    * **Windows:** 
-  ```bash
-  sudo apt-get install curl libcurl3 libcurl3-dev php
-  ```
-  **Note:** For **Windows**, you can download **PHP** from [here](http://windows.php.net/download/). Also, refer to this [documentation](http://php.net/manual/en/install.windows.php) for ensuring the accessibility of PHP through Command Prompt(cmd).
-
-* Download **composer** in the project directory ([Linux/MacOS](https://getcomposer.org/download/), [Windows](https://getcomposer.org/doc/00-intro.md#installation-windows)).
-
-  **Note:** To use the **composer** command directly, it either should have been downloaded in the project directory or should be accessible globally which can be done by the command below:
-  ```bash
-  mv composer.phar /usr/local/bin/composer
-  ```
-### Installing Selenium Dependencies And Tutorial Repo
-
-**Step 1:** Clone the TestMu AI’s Php-Selenium repository and navigate to the code directory as shown below:
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/php-selenium-sample
-cd Php-Selenium
-```
-**Step 2:** Install the composer dependencies in the current project directory using the command below:
-```bash
+git clone https://github.com/LambdaTest/php-selenium-sample && cd php-selenium-sample
 composer install
 ```
 
-### Setting Up Your Authentication
+Set your credentials as environment variables.
 
-Make sure you have your TestMu AI credentials with you to run test automation scripts on TestMu AI Selenium Grid. You can obtain these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) or through [TestMu AI Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
+**macOS / Linux:**
 
-**Step 3:** Set TestMu AI `Username` and `Access Key` in environment variables.
-  * For **Linux/macOS**:
-  ```bash
-  export LT_USERNAME="YOUR_USERNAME" export LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
-  * For **Windows**:
-  ```bash
-  set LT_USERNAME="YOUR_USERNAME" set LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
-
-## Run Your First Test
-
->**Test Scenario**: The sample LambdaTest.php file tests a sample to-do list app by marking couple items as done, adding a new item to the list and finally displaying the count of pending items as output.
-
-Let's check the sample test script [LambdaTest.php](https://github.com/LambdaTest-sample-test-frameworks/Php-Selenium/blob/master/tests/LambdaTest.php) file.
-
-### Configuration Of Your Test Capabilities
-
-**Step 4:** In the test script, you need to update your test capabilities. Here, the code will select the basic capabilities such as OS, browser, browser version and so on.
-
-```php
-//Basic Test Configurations For PHP
-
-$capabilities = array(
-    "build" => "your build name",
-    "name" => "your test name",
-    "platform" => "macOS High Sierra",
-    "browserName" => "Firefox",
-    "version" => "64.0",
-    "resolution" => "1280x1024",
-    "selenium_version" => "3.13.0",
-    "screenshot" => true,
-    "firefox.driver" => v0.23.0
-    )
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
-You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
 
+**Windows:**
 
-### Executing the Test
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
 
-**Step 5:** The tests can be executed in the terminal using the following command:
+### Run tests
 
 ```bash
 php Lambdatest.php
 ```
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on TestMu AI automation dashboard. 
 
-## Testing Locally Hosted Or Privately Hosted Projects
+View results on your TestMu AI dashboard.
 
-You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
+### Local testing with TestMu AI Tunnel
 
-Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) for more information.
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-Here’s how you can establish TestMu AI Tunnel.
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-Download the binary file of:
-* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+Add the following to your capabilities:
 
-Open command prompt and navigate to the binary folder.
-
-Run the following command:
-
-```bash
-LT -user {user’s login email} -key {user’s access key}
-```
-So if your user name is lambdatest@example.com and key is 123456, the command would be:
-
-```bash
-LT -user lambdatest@example.com -key 123456
-```
-Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
-
-**Tunnel Capability**
-
-```
- "tunnel" => true
+```js
+tunnel: true,
 ```
 
-## Tutorials 📙
+## Contributions
 
-Check out our latest tutorials on PHP automation testing 👇
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your PHP version, OS, and PHP Selenium binding version.
 
-* [10 of the Best PHP Testing Frameworks for 2021](https://www.testmuai.com/blog/best-php-testing-frameworks-2021/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Getting Started With Selenium PHP For Automation Testing](https://www.testmuai.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Web automation testing using Selenium PHP on cloud-based Selenium Grid](https://www.testmuai.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Handling Multiple Browser Windows and Tabs in Selenium PHP](https://www.testmuai.com/blog/handling-windows-in-selenium-with-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Work with Tables in Selenium PHP?](https://www.testmuai.com/blog/tables-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How To Open IE and Edge Browsers In Selenium WebDriver Using PHP](https://www.testmuai.com/blog/open-ie-and-edge-browser-in-selenium-webdriver-using-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Handle Synchronization in Selenium PHP Using Implicit and Explicit Wait?](https://www.testmuai.com/blog/implicit-explicit-wait-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Execute JavaScript in Selenium PHP?](https://www.testmuai.com/blog/executing-javascript-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Generate PHPUnit Coverage Report in HTML and XML?](https://www.testmuai.com/blog/phpunit-code-coverage-report-html/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Setup CI/CD Pipeline with Bamboo for PHP Projects?](https://www.testmuai.com/blog/how-to-setup-cicd-pipeline-with-bamboo-for-php-projects/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+## TestMu AI (Formerly LambdaTest) Community
 
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-## Documentation & Resources :books:
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-      
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)    
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-## TestMu AI Community :busts_in_silhouette:
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-## What's New At TestMu AI ❓
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-## 🚀 LambdaTest is Now TestMu AI
+### How LambdaTest Evolved into TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-### 🔄 Our Rebrand Journey
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+## Support
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# Run Selenium Tests With PHP On LambdaTest
+# Run Selenium Tests With PHP — TestMu AI (Formerly LambdaTest)
 
 ![image](https://user-images.githubusercontent.com/70570645/171994020-d3c81aca-bd93-4467-a372-ff0283fef8df.png)
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to run your PHP automation testing scripts on the LambdaTest platform*
+*Learn how to run your PHP automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
 
@@ -54,7 +54,7 @@ Before you begin automation testing with Selenium, you would need to:
   ```
 ### Installing Selenium Dependencies And Tutorial Repo
 
-**Step 1:** Clone the LambdaTest’s Php-Selenium repository and navigate to the code directory as shown below:
+**Step 1:** Clone the TestMu AI’s Php-Selenium repository and navigate to the code directory as shown below:
 
 ```bash
 git clone https://github.com/LambdaTest/php-selenium-sample
@@ -67,9 +67,9 @@ composer install
 
 ### Setting Up Your Authentication
 
-Make sure you have your LambdaTest credentials with you to run test automation scripts on LambdaTest Selenium Grid. You can obtain these credentials from the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) or through [LambdaTest Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
+Make sure you have your TestMu AI credentials with you to run test automation scripts on TestMu AI Selenium Grid. You can obtain these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) or through [TestMu AI Profile](https://accounts.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
 
-**Step 3:** Set LambdaTest `Username` and `Access Key` in environment variables.
+**Step 3:** Set TestMu AI `Username` and `Access Key` in environment variables.
   * For **Linux/macOS**:
   ```bash
   export LT_USERNAME="YOUR_USERNAME" export LT_ACCESS_KEY="YOUR ACCESS KEY"
@@ -104,7 +104,7 @@ $capabilities = array(
     "firefox.driver" => v0.23.0
     )
 ```
-You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.lambdatest.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
+You can generate capabilities for your test requirements with the help of our inbuilt [Desired Capability Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium).
 
 
 ### Executing the Test
@@ -114,20 +114,20 @@ You can generate capabilities for your test requirements with the help of our in
 ```bash
 php Lambdatest.php
 ```
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on LambdaTest automation dashboard. 
+Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on TestMu AI automation dashboard. 
 
 ## Testing Locally Hosted Or Privately Hosted Projects
 
-You can test your locally hosted or privately hosted projects with LambdaTest Selenium grid using LambdaTest Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. LambdaTest Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
+You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
 
-Refer our [LambdaTest Tunnel documentation](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) for more information.
+Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) for more information.
 
-Here’s how you can establish LambdaTest Tunnel.
+Here’s how you can establish TestMu AI Tunnel.
 
 Download the binary file of:
-* [LambdaTest Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [LambdaTest Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [LambdaTest Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 Open command prompt and navigate to the binary folder.
 
@@ -141,7 +141,7 @@ So if your user name is lambdatest@example.com and key is 123456, the command wo
 ```bash
 LT -user lambdatest@example.com -key 123456
 ```
-Once you are able to connect **LambdaTest Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
+Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
 
 **Tunnel Capability**
 
@@ -153,60 +153,50 @@ Once you are able to connect **LambdaTest Tunnel** successfully, you would just 
 
 Check out our latest tutorials on PHP automation testing 👇
 
-* [10 of the Best PHP Testing Frameworks for 2021](https://www.lambdatest.com/blog/best-php-testing-frameworks-2021/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Getting Started With Selenium PHP For Automation Testing](https://www.lambdatest.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Web automation testing using Selenium PHP on cloud-based Selenium Grid](https://www.lambdatest.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [Handling Multiple Browser Windows and Tabs in Selenium PHP](https://www.lambdatest.com/blog/handling-windows-in-selenium-with-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Work with Tables in Selenium PHP?](https://www.lambdatest.com/blog/tables-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How To Open IE and Edge Browsers In Selenium WebDriver Using PHP](https://www.lambdatest.com/blog/open-ie-and-edge-browser-in-selenium-webdriver-using-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Handle Synchronization in Selenium PHP Using Implicit and Explicit Wait?](https://www.lambdatest.com/blog/implicit-explicit-wait-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Execute JavaScript in Selenium PHP?](https://www.lambdatest.com/blog/executing-javascript-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Generate PHPUnit Coverage Report in HTML and XML?](https://www.lambdatest.com/blog/phpunit-code-coverage-report-html/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [How to Setup CI/CD Pipeline with Bamboo for PHP Projects?](https://www.lambdatest.com/blog/how-to-setup-cicd-pipeline-with-bamboo-for-php-projects/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [10 of the Best PHP Testing Frameworks for 2021](https://www.testmuai.com/blog/best-php-testing-frameworks-2021/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [Getting Started With Selenium PHP For Automation Testing](https://www.testmuai.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [Web automation testing using Selenium PHP on cloud-based Selenium Grid](https://www.testmuai.com/blog/selenium-php-tutorial/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [Handling Multiple Browser Windows and Tabs in Selenium PHP](https://www.testmuai.com/blog/handling-windows-in-selenium-with-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How to Work with Tables in Selenium PHP?](https://www.testmuai.com/blog/tables-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How To Open IE and Edge Browsers In Selenium WebDriver Using PHP](https://www.testmuai.com/blog/open-ie-and-edge-browser-in-selenium-webdriver-using-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How to Handle Synchronization in Selenium PHP Using Implicit and Explicit Wait?](https://www.testmuai.com/blog/implicit-explicit-wait-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How to Execute JavaScript in Selenium PHP?](https://www.testmuai.com/blog/executing-javascript-in-selenium-php/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How to Generate PHPUnit Coverage Report in HTML and XML?](https://www.testmuai.com/blog/phpunit-code-coverage-report-html/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [How to Setup CI/CD Pipeline with Bamboo for PHP Projects?](https://www.testmuai.com/blog/how-to-setup-cicd-pipeline-with-bamboo-for-php-projects/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
 
 
 ## Documentation & Resources :books:
 
       
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+**🔄 Our Rebrand Journey**
 
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-      
-## We are here to help you :headphones:
+**✨ Specialties**
 
-* Got a query? we are available 24x7 to help. [Contact Us](mailto:support@lambdatest.com)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=php-selenium)
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -192,11 +192,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code